### PR TITLE
expose internals?

### DIFF
--- a/bzlib-conduit.cabal
+++ b/bzlib-conduit.cabal
@@ -20,14 +20,13 @@ source-repository head
   location:            git://github.com/snoyberg/bzlib-conduit.git
 
 library
-  exposed-modules:     Data.Conduit.BZlib
-  other-modules:       Data.Conduit.BZlib.Internal
+  exposed-modules:     Data.Conduit.BZlib,
+                       Data.Conduit.BZlib.Internal
 
   build-depends:       base == 4.*
                      , bytestring >=0.9 && <0.11
                      , mtl == 2.*
                      , conduit >= 0.5 && < 1.3
-                     , conduit-extra >= 1.0 && < 1.2
                      , resourcet
                      , data-default
                      , bindings-DSL

--- a/bzlib-conduit.cabal
+++ b/bzlib-conduit.cabal
@@ -27,6 +27,7 @@ library
                      , bytestring >=0.9 && <0.11
                      , mtl == 2.*
                      , conduit >= 0.5 && < 1.3
+                     , conduit-extra >= 1.0 && < 1.2
                      , resourcet
                      , data-default
                      , bindings-DSL


### PR DESCRIPTION
There was some difficulty writing a 'pipes-bzlib' discussed on reddit https://www.reddit.com/r/haskell/comments/47p0ae/pipesbzip/ (the discussion will not be interesting to you). It is pretty simple to just use the bindings included here, if the internal module is exposed.  There may be some reason why, in the end, this wouldn't be the best route for a pipes-bzlib, I'm not sure. Ideally I guess there would be a little `streaming-commons-bzlib` package. As it is there are separate bzlib bindings for iteratee, conduit and lazy-bytestring and all of them hide the internal modules. 

By the way, the way this is set up - as a fork of the original repo, it is impossible to raise an issue; you can just send a patch. That is more what I intended to do.
