### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -1,3 +1,4 @@
+import Control.Monad.Trans.Resource
 import Data.Conduit
 import Data.Conduit.Binary
 import Data.Conduit.List as C

--- a/bzlib-conduit.cabal
+++ b/bzlib-conduit.cabal
@@ -67,3 +67,4 @@ benchmark bench
                      , conduit
                      , conduit-extra
                      , bzlib-conduit
+                     , resourcet


### PR DESCRIPTION
The benchmarks currently do not compile with GHC 8. Originally discovered in https://github.com/iu-parfunc/sc-haskell/issues/7
