### PR TITLE
Add system-bzip2 flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for bzlib-conduit
 
+## 0.3.0.4
+
+* Add system-bzip2 flag [#14](https://github.com/snoyberg/bzlib-conduit/pull/13)
+
 ## 0.3.0.3
 
 * CVE 2019 12900 [#11](https://github.com/snoyberg/bzlib-conduit/pull/11)

--- a/bzlib-conduit.cabal
+++ b/bzlib-conduit.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -36,6 +36,11 @@ source-repository head
   type: git
   location: https://github.com/snoyberg/bzlib-conduit
 
+flag system-bzip2
+  description: Use system bzip2 instead of bundled sources
+  manual: True
+  default: True
+
 library
   exposed-modules:
       Data.Conduit.BZlib
@@ -53,7 +58,7 @@ library
     , mtl >=2.0
     , resourcet >=1.2
   default-language: Haskell2010
-  if !(os(windows))
+  if !(os(windows)) && flag(system-bzip2)
     extra-libraries:
         bz2
   else

--- a/bzlib-conduit.cabal
+++ b/bzlib-conduit.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           bzlib-conduit
-version:        0.3.0.3
+version:        0.3.0.4
 synopsis:       Streaming compression/decompression via conduits.
 description:    Please see the README and docs at <https://www.stackage.org/package/bzlib-conduit>
 category:       Codec

--- a/package.yaml
+++ b/package.yaml
@@ -22,10 +22,16 @@ dependencies:
 - data-default-class
 - bindings-DSL
 
+flags:
+  system-bzip2:
+    description: Use system bzip2 instead of bundled sources
+    manual: True
+    default: True
+
 library:
   source-dirs: src
   when:
-  - condition: "!(os(windows))"
+  - condition: "!(os(windows)) && flag(system-bzip2)"
     then:
       extra-libraries: bz2
     else:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        bzlib-conduit
-version:     0.3.0.3
+version:     0.3.0.4
 synopsis:    Streaming compression/decompression via conduits.
 description: Please see the README and docs at <https://www.stackage.org/package/bzlib-conduit>
 category:    Codec

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,1 @@
-resolver: lts-22.13
-
-extra-deps:
-- bzip2-clib-1.0.8
+resolver: lts-23.0


### PR DESCRIPTION
Fixes #12 

The default behavior should be the same:

- on windows we unconditionally build static
- on non-windows we link dynamically by default, unless `system-bzip2` flag gets explicitly disabled